### PR TITLE
fix: fix clip-path css

### DIFF
--- a/src/style/sections/_contact.scss
+++ b/src/style/sections/_contact.scss
@@ -3,7 +3,7 @@
   -webkit-clip-path: polygon(0 15vh, 100% 0, 100% 100%, 0 100%);
   clip-path: polygon(0 15vh, 100% 0, 100% 100%, 0 100%);
   padding: 15rem 0 10rem 0;
-  margin-top: -10rem;
+  margin-top: -15rem;
   margin-bottom: -1px;
   color: $white-color;
 

--- a/src/style/sections/_projects.scss
+++ b/src/style/sections/_projects.scss
@@ -1,7 +1,7 @@
 #projects {
   background-color: $white-color;
   color: $dark-blue-text;
-  margin-top: -10rem;
+  margin-top: -15rem;
   padding-top: 15rem;
 
   @include respond(tab-land) {
@@ -63,8 +63,7 @@
         box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
         transition: all 0.2s ease-out;
         box-shadow: 0 6px 10px rgba(0, 0, 0, 0.08), 0 0 6px rgba(0, 0, 0, 0.05);
-        transition: 0.5s transform cubic-bezier(0.155, 1.105, 0.295, 1.12),
-          0.5s box-shadow,
+        transition: 0.5s transform cubic-bezier(0.155, 1.105, 0.295, 1.12), 0.5s box-shadow,
           0.5s -webkit-transform cubic-bezier(0.155, 1.105, 0.295, 1.12);
 
         @include respond(phone) {


### PR DESCRIPTION
This commit fixes **the top margin** to align with the `clip-path` for the contact and projects section.

**Before the fix**:
If you use a different background color as `$white-color`, you will see that the clip path doesn't align with the transformed clip path and shows a little white stripe.
![simplefolio clip path](https://i.imgur.com/Iuaw0WU.png)

**After the fix**:
no white stripe