### PR TITLE
Fixed bug where button borders don't display on Safari 13

### DIFF
--- a/src/style/components/_buttons.scss
+++ b/src/style/components/_buttons.scss
@@ -30,7 +30,8 @@
   );
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-  border: 2px solid transparent;
+  border-width: 2px;
+  border-style: solid;
   border-image: linear-gradient(
     135deg,
     $primary-color 0%,


### PR DESCRIPTION
In recent Safari (Mac) versions, there is a display bug with using linear-gradient for 'border-image'. The issue can be fixed by specifying 'border-width' and 'border-style' separately, instead of using the shorthand 'border'.