### PR TITLE
Fix the invalid example of html lang attribute.

### DIFF
--- a/src/mock/data.js
+++ b/src/mock/data.js
@@ -3,7 +3,7 @@ import { nanoid } from 'nanoid';
 // HEAD DATA
 export const headData = {
   title: '', // e.g: 'Name | Developer'
-  lang: '', // e.g: en, es, fr, jp
+  lang: '', // e.g: en, es, fr, ja
   description: '', // e.g: Welcome to my website
 };
 


### PR DESCRIPTION
# Fix the invalid example of html lang attribute.
- `jp` is not a lang code. It may be `ja` . 
    - https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry